### PR TITLE
Change message for open() failures

### DIFF
--- a/cli/zifbin
+++ b/cli/zifbin
@@ -37,7 +37,7 @@ filename: if omitted, will read from stdin
             with open(filename) as f:
                 data = f.read()
         except:
-            print 'file not found'
+            print('Error: could not open file or not found')
             sys.exit(-1)
     else:
         for line in sys.stdin:


### PR DESCRIPTION
Change the error message printer on open() failures to be consistent with other Error states, and cover  failures caused by things other than missing files.
