### PR TITLE
cli/zifbin: try to use pyopenssl with urllib3

### DIFF
--- a/cli/zifbin
+++ b/cli/zifbin
@@ -9,6 +9,13 @@ import sys
 from xdg import BaseDirectory
 
 
+try:
+    import requests.packages.urllib3.contrib.pyopenssl
+    requests.packages.urllib3.contrib.pyopenssl.inject_into_urllib3()
+except ImportError:
+    pass
+
+
 ##Pastes things to zifb.in
 def paste(expire=None, language=None, filename=None, tee=True):
     """Pastes things to https://zifb.in"""


### PR DESCRIPTION
Newer versions of requests try to do this automatically, but older ones
may not.  This gives modern SSL support to old Pythons (basically
anything before 2.7.9).

You'll probably want to add a dep for ndg-httpsclient for Python <= 2.7.9.  This code needs that for one tiny thing, and that'll pull in pyopenssl, cryptography, pyasn1, and idna for you (which are also needed).