### PR TITLE
api: Don't try to parse nil expiration dates

### DIFF
--- a/api/v1.py
+++ b/api/v1.py
@@ -72,9 +72,13 @@ def paste():  # noqa: C901
         paste.name = random_string()
 
     paste.save()
-    return json.dumps(
-        {
-            "paste": "{0}{1}".format(domain, paste.name),
-            "expires": pendulum.instance(paste.expire).to_datetime_string(),
-        }
-    )
+
+    returnbody = {}
+    returnbody["paste"] = "{0}{1}".format(domain, paste.name)
+
+    if paste.expire is not None:
+        returnbody["expires"] = pendulum.instance(paste.expire).to_datetime_string()
+    else:
+        returnbody["expires"] = "0"
+
+    return json.dumps(returnbody)


### PR DESCRIPTION
The expiration date is kept as `None` if the user is logged in and didn't set an expiration date.
This will later fail when trying to generate the JSON response (which includes said expiration date) and cause an Internal Server Error.

Fix the issue by returning "0" if the expiration date is unlimited (and generate the date as usual otherwise).